### PR TITLE
fix: use unix-style paths for action invocation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,9 @@ inputs:
 
 runs:
   using: 'node16'
-  pre:  'dist\pre\index.js'
-  main: 'dist\main\index.js'
-  post: 'dist\post\index.js'
+  pre:  'dist/pre/index.js'
+  main: 'dist/main/index.js'
+  post: 'dist/post/index.js'
 
 branding:
   icon: 'box'


### PR DESCRIPTION
Fixes and closes Caphyon/advinst-github-action#9, which describes a failure on macOS or Linux runners when the action is otherwise inert.

Github runners accept Unix-style paths always, whereas Windows style paths seem to fail on non-Windows runners. Thus, this change should be transparent for Windows users and should fix the error filed in #9 for macOS and Linux runners.